### PR TITLE
Relic hooks

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/relicInterfaces/ActualOnSmithRelicPatch.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/relicInterfaces/ActualOnSmithRelicPatch.java
@@ -1,0 +1,20 @@
+package com.evacipated.cardcrawl.mod.stslib.patches.relicInterfaces;
+
+import com.evacipated.cardcrawl.mod.stslib.relics.ActualOnSmithRelic;
+import com.evacipated.cardcrawl.modthespire.lib.SpireInsertPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+import com.megacrit.cardcrawl.vfx.campfire.CampfireSmithEffect;
+
+@SpirePatch(clz = CampfireSmithEffect.class, method = "update")
+public class ActualOnSmithRelicPatch {
+    @SpireInsertPatch(rloc=13)
+    public static void Insert(CampfireSmithEffect __instance) {
+        for (AbstractRelic r : AbstractDungeon.player.relics) {
+            if (r instanceof ActualOnSmithRelic) {
+                ((ActualOnSmithRelic)r).actualOnSmith();
+            }
+        }
+    }
+}

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/relicInterfaces/OnRemoveCardFromMasterDeckPatch.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/relicInterfaces/OnRemoveCardFromMasterDeckPatch.java
@@ -1,0 +1,19 @@
+package com.evacipated.cardcrawl.mod.stslib.patches.relicInterfaces;
+
+import com.evacipated.cardcrawl.mod.stslib.relics.OnRemoveCardFromMasterDeckRelic;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+
+@SpirePatch(clz = CardGroup.class, method = "removeCard", paramtypez = AbstractCard.class)
+public class OnRemoveCardFromMasterDeckPatch {
+    public static void Postfix(CardGroup __instance, AbstractCard c) {
+        for (AbstractRelic r : AbstractDungeon.player.relics) {
+            if (r instanceof OnRemoveCardFromMasterDeckRelic && __instance.type == CardGroup.CardGroupType.MASTER_DECK) {
+                ((OnRemoveCardFromMasterDeckRelic) r).onRemoveCardFromMasterDeck(c);
+            }
+        }
+    }
+}

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/relicInterfaces/OnSkipCardRelicPatch.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/relicInterfaces/OnSkipCardRelicPatch.java
@@ -1,0 +1,38 @@
+package com.evacipated.cardcrawl.mod.stslib.patches.relicInterfaces;
+
+import com.evacipated.cardcrawl.mod.stslib.relics.OnSkipCardRelic;
+import com.evacipated.cardcrawl.modthespire.lib.SpireInsertPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+import com.megacrit.cardcrawl.relics.SingingBowl;
+import com.megacrit.cardcrawl.screens.CardRewardScreen;
+import com.megacrit.cardcrawl.ui.buttons.ProceedButton;
+import com.megacrit.cardcrawl.ui.buttons.SingingBowlButton;
+
+public class OnSkipCardRelicPatch {
+    @SpirePatch(clz = SingingBowlButton.class, method = "onClick")
+    public static class SingingBowlSkipPatch {
+        public static void Prefix(SingingBowlButton __instance) {
+            for (AbstractRelic r : AbstractDungeon.player.relics) {
+                if (r instanceof OnSkipCardRelic) {
+                    if (AbstractDungeon.player.hasRelic(SingingBowl.ID)) {
+                        ((OnSkipCardRelic)r).onSkipSingingBowl();
+                    }
+                }
+            }
+        }
+    }
+
+    @SpirePatch(clz = ProceedButton.class, method = "update")
+    public static class OnSkipCardPatch {
+        @SpireInsertPatch(rloc=102)
+        public static void Insert(ProceedButton __instance) {
+            for (AbstractRelic r : AbstractDungeon.player.relics) {
+                if (r instanceof OnSkipCardRelic) {
+                    ((OnSkipCardRelic)r).onSkipCard();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/relics/ActualOnSmithRelic.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/relics/ActualOnSmithRelic.java
@@ -1,0 +1,5 @@
+package com.evacipated.cardcrawl.mod.stslib.relics;
+
+public interface ActualOnSmithRelic {
+    void actualOnSmith();
+}

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/relics/OnRemoveCardFromMasterDeckRelic.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/relics/OnRemoveCardFromMasterDeckRelic.java
@@ -1,0 +1,7 @@
+package com.evacipated.cardcrawl.mod.stslib.relics;
+
+import com.megacrit.cardcrawl.cards.AbstractCard;
+
+public interface OnRemoveCardFromMasterDeckRelic {
+        void onRemoveCardFromMasterDeck(AbstractCard c);
+}

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/relics/OnSkipCardRelic.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/relics/OnSkipCardRelic.java
@@ -1,0 +1,6 @@
+package com.evacipated.cardcrawl.mod.stslib.relics;
+
+public interface OnSkipCardRelic {
+    void onSkipSingingBowl();
+    void onSkipCard();
+}


### PR DESCRIPTION
Adds a fix to Base Game OnSmith.
Allows relics to proc off of removing a card from master deck or skipping a card (includes singing bowl).