### PR TITLE
Common keyword icons

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/StSLib.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/StSLib.java
@@ -32,6 +32,11 @@ public class StSLib implements
         OnStartBattleSubscriber
 {
     public static Texture TEMP_HP_ICON;
+    public static Texture BADGE_EXHAUST;
+    public static Texture BADGE_ETHEREAL;
+    public static Texture BADGE_INNATE;
+    public static Texture BADGE_PURGE;
+    public static Texture BADGE_RETAIN;
 
     public static void initialize()
     {
@@ -42,6 +47,11 @@ public class StSLib implements
     public void receivePostInitialize()
     {
         TEMP_HP_ICON = ImageMaster.loadImage("images/stslib/ui/tempHP.png");
+        BADGE_EXHAUST = ImageMaster.loadImage("images/stslib/ui/keywordIcons/Exhaust.png");
+        BADGE_ETHEREAL = ImageMaster.loadImage("images/stslib/ui/keywordIcons/Ethereal.png");
+        BADGE_INNATE = ImageMaster.loadImage("images/stslib/ui/keywordIcons/Innate.png");
+        BADGE_PURGE = ImageMaster.loadImage("images/stslib/ui/keywordIcons/Purge.png");
+        BADGE_RETAIN = ImageMaster.loadImage("images/stslib/ui/keywordIcons/Retain.png");
     }
 
     private void loadLangKeywords(String language)

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/StSLib.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/StSLib.java
@@ -6,12 +6,14 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.evacipated.cardcrawl.mod.stslib.cards.interfaces.StartupCard;
+import com.evacipated.cardcrawl.mod.stslib.patches.CommonKeywordIconsPatches;
 import com.evacipated.cardcrawl.mod.stslib.variables.ExhaustiveVariable;
 import com.evacipated.cardcrawl.mod.stslib.variables.RefundVariable;
 import com.evacipated.cardcrawl.modthespire.lib.SpireInitializer;
 import com.google.gson.Gson;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.CardGroup;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.ImageMaster;
@@ -52,6 +54,8 @@ public class StSLib implements
         BADGE_INNATE = ImageMaster.loadImage("images/stslib/ui/keywordIcons/Innate.png");
         BADGE_PURGE = ImageMaster.loadImage("images/stslib/ui/keywordIcons/Purge.png");
         BADGE_RETAIN = ImageMaster.loadImage("images/stslib/ui/keywordIcons/Retain.png");
+
+        CommonKeywordIconsPatches.purgeName = BaseMod.getKeywordProper("purge");
     }
 
     private void loadLangKeywords(String language)

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/fields/cards/AbstractCard/CommonKeywordIconsField.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/fields/cards/AbstractCard/CommonKeywordIconsField.java
@@ -1,0 +1,13 @@
+package com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+
+@SpirePatch(
+        clz = AbstractCard.class,
+        method=SpirePatch.CLASS
+)
+public class CommonKeywordIconsField {
+    public static SpireField<Boolean> useIcons = new SpireField<>(() -> true);
+}

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/fields/cards/AbstractCard/CommonKeywordIconsField.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/fields/cards/AbstractCard/CommonKeywordIconsField.java
@@ -9,5 +9,5 @@ import com.megacrit.cardcrawl.cards.AbstractCard;
         method=SpirePatch.CLASS
 )
 public class CommonKeywordIconsField {
-    public static SpireField<Boolean> useIcons = new SpireField<>(() -> true);
+    public static SpireField<Boolean> useIcons = new SpireField<>(() -> false);
 }

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/CommonKeywordIconsPatches.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/CommonKeywordIconsPatches.java
@@ -1,0 +1,338 @@
+package com.evacipated.cardcrawl.mod.stslib.patches;
+
+import basemod.ReflectionHacks;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.GlyphLayout;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.Vector2;
+import com.evacipated.cardcrawl.mod.stslib.StSLib;
+import com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.CommonKeywordIconsField;
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.helpers.Hitbox;
+import com.megacrit.cardcrawl.helpers.PowerTip;
+import com.megacrit.cardcrawl.helpers.TipHelper;
+import com.megacrit.cardcrawl.screens.SingleCardViewPopup;
+import javassist.CtBehavior;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+
+public class CommonKeywordIconsPatches {
+    //Hook into AbstractCard render methods (above renderType) and call the badge rendering logic if the relevant field is set.
+    @SpirePatch(
+            clz= AbstractCard.class,
+            method="renderCard"
+    )
+    public static class RenderIcons
+    {
+        @SpireInsertPatch(
+                locator= Locator.class
+        )
+        public static void patch(AbstractCard __instance, SpriteBatch sb, boolean hovered, boolean selected)
+        {
+            if(CommonKeywordIconsField.useIcons.get(__instance)) {
+                RenderBadges(sb, __instance);
+            }
+        }
+
+        private static class Locator extends SpireInsertLocator
+        {
+            @Override
+            public int[] Locate(CtBehavior ctMethodToPatch) throws Exception
+            {
+                Matcher finalMatcher = new Matcher.MethodCallMatcher(AbstractCard.class, "renderType");
+                return LineFinder.findInOrder(ctMethodToPatch, finalMatcher);
+            }
+        }
+    }
+
+    @SpirePatch(
+            clz= AbstractCard.class,
+            method="renderInLibrary"
+    )
+    public static class RenderIconsInLibrary
+    {
+        @SpireInsertPatch(
+                locator= Locator.class
+        )
+        public static void patch(AbstractCard __instance, SpriteBatch sb)
+        {
+            if(CommonKeywordIconsField.useIcons.get(__instance)) {
+                RenderBadges(sb, __instance);
+            }
+        }
+
+        private static class Locator extends SpireInsertLocator
+        {
+            @Override
+            public int[] Locate(CtBehavior ctMethodToPatch) throws Exception
+            {
+                Matcher finalMatcher = new Matcher.MethodCallMatcher(AbstractCard.class, "renderType");
+                return LineFinder.findInOrder(ctMethodToPatch, finalMatcher);
+            }
+        }
+    }
+
+    //Add Keyword powertips when the card uses the icons and make sure there are no duplicates
+    @SpirePatch(clz = TipHelper.class, method = "renderTipForCard")
+    public static class RenderKeywords {
+        @SpireInsertPatch(locator = Locator.class)
+        public static void patch(AbstractCard c, SpriteBatch sb, @ByRef ArrayList<String>[] keywords) {
+            if(CommonKeywordIconsField.useIcons.get(c)) {
+                if (c.isInnate)
+                {
+                    keywords[0].add("innate");
+                }
+                if (c.isEthereal)
+                {
+                    keywords[0].add("ethereal");
+                }
+                if (c.retain || c.selfRetain)
+                {
+                    keywords[0].add("retain");
+                }
+                if (c.purgeOnUse)
+                {
+                    keywords[0].add("purge");
+                }
+                if (c.exhaust || c.exhaustOnUseOnce)
+                {
+                    keywords[0].add("exhaust");
+                }
+
+                keywords[0] = keywords[0].stream().distinct().collect(Collectors.toCollection(ArrayList::new));
+            }
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            @Override
+            public int[] Locate(CtBehavior ctBehavior) throws Exception {
+                Matcher finalMatcher = new Matcher.FieldAccessMatcher(TipHelper.class, "KEYWORDS");
+                return LineFinder.findInOrder(ctBehavior, finalMatcher);
+            }
+        }
+    }
+
+    //Render icon on keyword powertips for clarity. Sadly I can't only enable this only on cards that have the keywords without a lot more effort than I'm willing to put into this
+    @SpirePatch(
+            clz = TipHelper.class,
+            method = "renderBox"
+    )
+    public static class RenderIconOnTips {
+        @SpirePostfixPatch
+        public static void patch(SpriteBatch sb, String word, float x, float y) {
+            Texture badge = null;
+            if (word.equals("innate"))
+            {
+                badge = StSLib.BADGE_INNATE;
+            }
+            else if (word.equals("ethereal"))
+            {
+                badge = StSLib.BADGE_ETHEREAL;
+            }
+            else if (word.equals("retain"))
+            {
+                badge = StSLib.BADGE_RETAIN;
+            }
+            else if (word.equals("purge"))
+            {
+                badge = StSLib.BADGE_PURGE;
+            }
+            else if (word.equals("exhaust"))
+            {
+                badge = StSLib.BADGE_EXHAUST;
+            }
+
+            if(badge != null) {
+                float badge_w = badge.getWidth();
+                float badge_h = badge.getHeight();
+                sb.draw(badge, x + ((320.0F - badge_w/2 - 8f) * Settings.scale), y + (-16.0F * Settings.scale), 0, 0, badge_w, badge_h,
+                        0.5f * Settings.scale, 0.5f * Settings.scale, 0, 0, 0, (int)badge_w, (int)badge_h, false, false);
+            }
+        }
+    }
+
+    //Render in single card view madness
+    private static Field cardField = null;
+    private static Field cardHbField = null;
+
+
+    @SpirePatch(
+            clz = SingleCardViewPopup.class,
+            method = "render"
+    )
+    public static class SingleCardViewRenderIconOnCard {
+        @SpireInsertPatch(
+                locator = Locator.class
+        )
+        public static void patch(SingleCardViewPopup __instance, SpriteBatch sb) throws IllegalAccessException {
+            if(cardField == null) {
+                try {
+                    cardField = SingleCardViewPopup.class.getDeclaredField("card");
+                    cardField.setAccessible(true);
+                } catch (Exception e) {}
+            }
+            AbstractCard c = (AbstractCard) cardField.get(__instance);
+
+            if(CommonKeywordIconsField.useIcons.get(c)) {
+                if(cardHbField == null) {
+                    try {
+                        cardHbField = SingleCardViewPopup.class.getDeclaredField("cardHb");
+                        cardHbField.setAccessible(true);
+                    } catch (Exception e) {}
+                }
+                Hitbox cardHb = (Hitbox) cardHbField.get(__instance);
+
+                int offset_y = 0;
+                if (c.isInnate) {
+                    drawBadge(sb, c, cardHb, StSLib.BADGE_INNATE, offset_y);
+                    offset_y++;
+                }
+                if (c.isEthereal) {
+                    drawBadge(sb, c, cardHb, StSLib.BADGE_ETHEREAL, offset_y);
+                    offset_y++;
+                }
+                if (c.retain || c.selfRetain) {
+                    drawBadge(sb, c, cardHb, StSLib.BADGE_RETAIN, offset_y);
+                    offset_y++;
+                }
+                if (c.purgeOnUse) {
+                    drawBadge(sb, c, cardHb, StSLib.BADGE_PURGE, offset_y);
+                    offset_y++;
+                }
+                if (c.exhaust || c.exhaustOnUseOnce) {
+                    drawBadge(sb, c, cardHb, StSLib.BADGE_EXHAUST, offset_y);
+                    offset_y++;
+                }
+            }
+
+        }
+
+        private static void drawBadge(SpriteBatch sb, AbstractCard card, Hitbox hb, Texture img, int offset) {
+            float badge_w = img.getWidth();
+            float badge_h = img.getHeight();
+            sb.draw(img, hb.x + hb.width - (badge_w * Settings.scale) * 0.66f, hb.y + hb.height - (badge_h * Settings.scale) * 0.5f - ((offset * (badge_h * Settings.scale)*0.6f)), 0, 0, badge_w * Settings.scale, badge_h * Settings.scale,
+                    Settings.scale, Settings.scale, card.angle, 0, 0, (int)badge_w, (int)badge_h, false, false);
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            @Override
+            public int[] Locate(CtBehavior ctBehavior) throws Exception {
+                Matcher finalMatcher = new Matcher.MethodCallMatcher(SingleCardViewPopup.class, "renderTips");
+                return LineFinder.findInOrder(ctBehavior, finalMatcher);
+            }
+        }
+    }
+
+    @SpirePatch(
+            clz = TipHelper.class,
+            method = "renderPowerTips"
+    )
+    public static class SingleCardViewRenderIconOnTips {
+        @SpireInsertPatch(
+                locator = Locator.class,
+                localvars = {"tip"}
+        )
+        public static void patch(float x, float y, SpriteBatch sb, ArrayList<PowerTip> powerTips, PowerTip tip) {
+            Texture badge = null;
+            if (tip.header.equalsIgnoreCase("innate"))
+            {
+                badge = StSLib.BADGE_INNATE;
+            }
+            else if (tip.header.equalsIgnoreCase("ethereal"))
+            {
+                badge = StSLib.BADGE_ETHEREAL;
+            }
+            else if (tip.header.equalsIgnoreCase("retain"))
+            {
+                badge = StSLib.BADGE_RETAIN;
+            }
+            else if (tip.header.equalsIgnoreCase("purge"))
+            {
+                badge = StSLib.BADGE_PURGE;
+            }
+            else if (tip.header.equalsIgnoreCase("exhaust"))
+            {
+                badge = StSLib.BADGE_EXHAUST;
+            }
+
+            if(badge != null) {
+                float badge_w = badge.getWidth();
+                float badge_h = badge.getHeight();
+                sb.draw(badge, x + ((320.0F - badge_w/2 - 8f) * Settings.scale), y + (-16.0F * Settings.scale), 0, 0, badge_w, badge_h,
+                        0.5f * Settings.scale, 0.5f * Settings.scale, 0, 0, 0, (int)badge_w, (int)badge_h, false, false);
+            }
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            @Override
+            public int[] Locate(CtBehavior ctBehavior) throws Exception {
+                Matcher finalMatcher = new Matcher.MethodCallMatcher(GlyphLayout.class, "setText");
+                return LineFinder.findInOrder(ctBehavior, finalMatcher);
+            }
+        }
+    }
+
+    //The below code was written by EatYourBeetS (https://github.com/EatYourBeetS) with minimal changes made by me (gkjzhgffjh)
+    private static void RenderBadges(SpriteBatch sb, AbstractCard card)
+    {
+        final float alpha = card.transparency; //UpdateBadgeAlpha(card);
+
+        int offset_y = 0;
+        if (card.isInnate)
+        {
+            offset_y -= RenderBadge(sb, card, StSLib.BADGE_INNATE, offset_y, alpha);
+        }
+        if (card.isEthereal)
+        {
+            offset_y -= RenderBadge(sb, card,  StSLib.BADGE_ETHEREAL, offset_y, alpha);
+        }
+        if (card.retain || card.selfRetain)
+        {
+            offset_y -= RenderBadge(sb, card,  StSLib.BADGE_RETAIN, offset_y, alpha);
+        }
+        if (card.purgeOnUse)
+        {
+            offset_y -= RenderBadge(sb, card,  StSLib.BADGE_PURGE, offset_y, alpha);
+        }
+        if (card.exhaust || card.exhaustOnUseOnce)
+        {
+            offset_y -= RenderBadge(sb, card,  StSLib.BADGE_EXHAUST, offset_y, alpha);
+        }
+    }
+
+    private static float RenderBadge(SpriteBatch sb, AbstractCard card, Texture texture, float offset_y, float alpha)
+    {
+        Vector2 offset = new Vector2(AbstractCard.RAW_W * 0.45f, AbstractCard.RAW_H * 0.45f + offset_y);
+
+        DrawOnCardAuto(sb, card, texture, offset, 64, 64, Color.WHITE, alpha, 1);
+
+        return 38;
+    }
+
+    //Rendering code
+    private static void DrawOnCardAuto(SpriteBatch sb, AbstractCard card, Texture img, Vector2 offset, float width, float height, Color color, float alpha, float scaleModifier)
+    {
+        if (card.angle != 0)
+        {
+            offset.rotate(card.angle);
+        }
+
+        offset.scl(Settings.scale * card.drawScale);
+
+        DrawOnCardCentered(sb, card, new Color(color.r, color.g, color.b, alpha), img, card.current_x + offset.x, card.current_y + offset.y, width, height, scaleModifier);
+    }
+
+    private static void DrawOnCardCentered(SpriteBatch sb, AbstractCard card, Color color, Texture img, float drawX, float drawY, float width, float height, float scaleModifier)
+    {
+        final float scale = card.drawScale * Settings.scale * scaleModifier;
+
+        sb.setColor(color);
+        sb.draw(img, drawX - (width / 2f), drawY - (height / 2f), width / 2f, height / 2f, width, height,
+                scale, scale, card.angle, 0, 0, img.getWidth(), img.getHeight(), false, false);
+    }
+}

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/CommonKeywordIconsPatches.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/CommonKeywordIconsPatches.java
@@ -215,7 +215,7 @@ public class CommonKeywordIconsPatches {
         private static void drawBadge(SpriteBatch sb, AbstractCard card, Hitbox hb, Texture img, int offset) {
             float badge_w = img.getWidth();
             float badge_h = img.getHeight();
-            sb.draw(img, hb.x + hb.width - (badge_w * Settings.scale) * 0.66f, hb.y + hb.height - (badge_h * Settings.scale) * 0.5f - ((offset * (badge_h * Settings.scale)*0.6f)), 0, 0, badge_w * Settings.scale, badge_h * Settings.scale,
+            sb.draw(img, hb.x + hb.width - (badge_w * Settings.scale) * 0.66f, hb.y + hb.height - (badge_h * Settings.scale) * 0.5f - ((offset * (badge_h * Settings.scale)*0.6f)), 0, 0, badge_w , badge_h ,
                     Settings.scale, Settings.scale, card.angle, 0, 0, (int)badge_w, (int)badge_h, false, false);
         }
 

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/CommonKeywordIconsPatches.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/CommonKeywordIconsPatches.java
@@ -11,9 +11,11 @@ import com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.CommonKeywo
 import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.helpers.GameDictionary;
 import com.megacrit.cardcrawl.helpers.Hitbox;
 import com.megacrit.cardcrawl.helpers.PowerTip;
 import com.megacrit.cardcrawl.helpers.TipHelper;
+import com.megacrit.cardcrawl.localization.KeywordStrings;
 import com.megacrit.cardcrawl.screens.SingleCardViewPopup;
 import javassist.CtBehavior;
 
@@ -22,6 +24,8 @@ import java.util.ArrayList;
 import java.util.stream.Collectors;
 
 public class CommonKeywordIconsPatches {
+    public static String purgeName = null;
+
     //Hook into AbstractCard render methods (above renderType) and call the badge rendering logic if the relevant field is set.
     @SpirePatch(
             clz= AbstractCard.class,
@@ -85,23 +89,23 @@ public class CommonKeywordIconsPatches {
             if(CommonKeywordIconsField.useIcons.get(c)) {
                 if (c.isInnate)
                 {
-                    keywords[0].add("innate");
+                    keywords[0].add(GameDictionary.INNATE.NAMES[0]);
                 }
                 if (c.isEthereal)
                 {
-                    keywords[0].add("ethereal");
+                    keywords[0].add(GameDictionary.ETHEREAL.NAMES[0]);
                 }
                 if (c.retain || c.selfRetain)
                 {
-                    keywords[0].add("retain");
+                    keywords[0].add(GameDictionary.RETAIN.NAMES[0]);
                 }
                 if (c.purgeOnUse)
                 {
-                    keywords[0].add("purge");
+                    keywords[0].add(purgeName);
                 }
                 if (c.exhaust || c.exhaustOnUseOnce)
                 {
-                    keywords[0].add("exhaust");
+                    keywords[0].add(GameDictionary.EXHAUST.NAMES[0]);
                 }
 
                 keywords[0] = keywords[0].stream().distinct().collect(Collectors.toCollection(ArrayList::new));
@@ -126,23 +130,23 @@ public class CommonKeywordIconsPatches {
         @SpirePostfixPatch
         public static void patch(SpriteBatch sb, String word, float x, float y) {
             Texture badge = null;
-            if (word.equals("innate"))
+            if (word.equals(GameDictionary.INNATE.NAMES[0]))
             {
                 badge = StSLib.BADGE_INNATE;
             }
-            else if (word.equals("ethereal"))
+            else if (word.equals(GameDictionary.ETHEREAL.NAMES[0]))
             {
                 badge = StSLib.BADGE_ETHEREAL;
             }
-            else if (word.equals("retain"))
+            else if (word.equals(GameDictionary.RETAIN.NAMES[0]))
             {
                 badge = StSLib.BADGE_RETAIN;
             }
-            else if (word.equals("purge"))
+            else if (word.equals(purgeName))
             {
                 badge = StSLib.BADGE_PURGE;
             }
-            else if (word.equals("exhaust"))
+            else if (word.equals(GameDictionary.EXHAUST.NAMES[0]))
             {
                 badge = StSLib.BADGE_EXHAUST;
             }
@@ -174,7 +178,7 @@ public class CommonKeywordIconsPatches {
                 try {
                     cardField = SingleCardViewPopup.class.getDeclaredField("card");
                     cardField.setAccessible(true);
-                } catch (Exception e) {}
+                } catch (Exception ignored) {}
             }
             AbstractCard c = (AbstractCard) cardField.get(__instance);
 
@@ -183,7 +187,7 @@ public class CommonKeywordIconsPatches {
                     try {
                         cardHbField = SingleCardViewPopup.class.getDeclaredField("cardHb");
                         cardHbField.setAccessible(true);
-                    } catch (Exception e) {}
+                    } catch (Exception ignored) {}
                 }
                 Hitbox cardHb = (Hitbox) cardHbField.get(__instance);
 
@@ -239,23 +243,23 @@ public class CommonKeywordIconsPatches {
         )
         public static void patch(float x, float y, SpriteBatch sb, ArrayList<PowerTip> powerTips, PowerTip tip) {
             Texture badge = null;
-            if (tip.header.equalsIgnoreCase("innate"))
+            if (tip.header.equalsIgnoreCase(GameDictionary.INNATE.NAMES[0]))
             {
                 badge = StSLib.BADGE_INNATE;
             }
-            else if (tip.header.equalsIgnoreCase("ethereal"))
+            else if (tip.header.equalsIgnoreCase(GameDictionary.ETHEREAL.NAMES[0]))
             {
                 badge = StSLib.BADGE_ETHEREAL;
             }
-            else if (tip.header.equalsIgnoreCase("retain"))
+            else if (tip.header.equalsIgnoreCase(GameDictionary.RETAIN.NAMES[0]))
             {
                 badge = StSLib.BADGE_RETAIN;
             }
-            else if (tip.header.equalsIgnoreCase("purge"))
+            else if (tip.header.equalsIgnoreCase(purgeName))
             {
                 badge = StSLib.BADGE_PURGE;
             }
-            else if (tip.header.equalsIgnoreCase("exhaust"))
+            else if (tip.header.equalsIgnoreCase(GameDictionary.EXHAUST.NAMES[0]))
             {
                 badge = StSLib.BADGE_EXHAUST;
             }

--- a/src/main/resources/images/stslib/ui/keywordIcons/Ethereal.png
+++ b/src/main/resources/images/stslib/ui/keywordIcons/Ethereal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e78089432cbd1aa2a25bfea8eccaa4c5abfd45568c05d71fcfb792183aaa0b2a
+size 4051

--- a/src/main/resources/images/stslib/ui/keywordIcons/Exhaust.png
+++ b/src/main/resources/images/stslib/ui/keywordIcons/Exhaust.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdefe3fb0c93a40fcd489358a5e494ae57879ed6a5694b92cad28e3a9da3e2da
+size 3612

--- a/src/main/resources/images/stslib/ui/keywordIcons/Innate.png
+++ b/src/main/resources/images/stslib/ui/keywordIcons/Innate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0e14e62d995fcc916ee0bf676edd81659f562a6eeee8b50bcd6f14207b0accc
+size 3797

--- a/src/main/resources/images/stslib/ui/keywordIcons/Purge.png
+++ b/src/main/resources/images/stslib/ui/keywordIcons/Purge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:063da4d73fe2cf8ae230e90edde33fdaf1e414a79ab65a25469acc97cad2d637
+size 3826

--- a/src/main/resources/images/stslib/ui/keywordIcons/Retain.png
+++ b/src/main/resources/images/stslib/ui/keywordIcons/Retain.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d5be18f2cde5c2dbbecd4e94d756b9e99f489a7c3e072c1961cedb19e400edd
+size 3792


### PR DESCRIPTION
Adds icons to powertips and cards that have a spirefield set for them that are supposed to substitute common keywords such as Exhaust, Innate, Ethereal, Purge and Retain.