### PR TITLE
Fix #19 Writhing Mass intent changing when stunned

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/StunMonsterPatch.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/StunMonsterPatch.java
@@ -1,29 +1,46 @@
 package com.evacipated.cardcrawl.mod.stslib.patches;
 
+import com.evacipated.cardcrawl.mod.stslib.powers.StunMonsterPower;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpireReturn;
+import com.megacrit.cardcrawl.actions.GameActionManager;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import javassist.CannotCompileException;
 import javassist.expr.ExprEditor;
 import javassist.expr.MethodCall;
 
-@SpirePatch(
-        cls="com.megacrit.cardcrawl.actions.GameActionManager",
-        method="getNextAction"
-)
-public class StunMonsterPatch
-{
-    public static ExprEditor Instrument()
-    {
-        return new ExprEditor() {
-            @Override
-            public void edit(MethodCall m) throws CannotCompileException
-            {
-                if (m.getClassName().equals("com.megacrit.cardcrawl.monsters.AbstractMonster")
-                        && m.getMethodName().equals("takeTurn")) {
-                    m.replace("if (!m.hasPower(com.evacipated.cardcrawl.mod.stslib.powers.StunMonsterPower.POWER_ID)) {" +
-                            "$_ = $proceed($$);" +
-                            "}");
+public class StunMonsterPatch {
+    @SpirePatch(
+            clz = GameActionManager.class,
+            method = "getNextAction"
+    )
+    public static class GetNextAction {
+        public static ExprEditor Instrument() {
+            return new ExprEditor() {
+                @Override
+                public void edit(MethodCall m) throws CannotCompileException {
+                    if (m.getClassName().equals("com.megacrit.cardcrawl.monsters.AbstractMonster")
+                            && m.getMethodName().equals("takeTurn")) {
+                        m.replace("if (!m.hasPower(com.evacipated.cardcrawl.mod.stslib.powers.StunMonsterPower.POWER_ID)) {" +
+                                "$_ = $proceed($$);" +
+                                "}");
+                    }
                 }
+            };
+        }
+    }
+
+    @SpirePatch(
+            clz = AbstractMonster.class,
+            method = "rollMove"
+    )
+    public static class RollMove {
+        public static SpireReturn<Void> Prefix(AbstractMonster __instance) {
+            if (__instance.hasPower(StunMonsterPower.POWER_ID)) {
+                return SpireReturn.Return(null);
+            } else {
+                return SpireReturn.Continue();
             }
-        };
+        }
     }
 }


### PR DESCRIPTION
When you attack Writhing Mass while it is Stunned, it changes its intent (only the intent; it doesn't move). This PR fixes that, it now stays Stunned even after you attack it.

This affects `AbstractDungeon.aiRng` by SpireReturn-ing early from `AbstractMonster::rollMove()`. I think this change makes more sense.