### PR TITLE
Fixing invisible power application because it is bad

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/powerInterfaces/InvisiblePowerPatch.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/powerInterfaces/InvisiblePowerPatch.java
@@ -1,11 +1,17 @@
 package com.evacipated.cardcrawl.mod.stslib.patches.powerInterfaces;
 
 import com.evacipated.cardcrawl.mod.stslib.powers.interfaces.InvisiblePower;
-import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import com.megacrit.cardcrawl.vfx.combat.PowerBuffEffect;
+import com.megacrit.cardcrawl.vfx.combat.PowerDebuffEffect;
 import javassist.CannotCompileException;
+import javassist.CtBehavior;
 import javassist.expr.ExprEditor;
 import javassist.expr.MethodCall;
 
@@ -77,6 +83,49 @@ public class InvisiblePowerPatch
                                     "$_ = $proceed($$);" +
                                     "}");
                         }
+                    }
+                }
+            };
+        }
+    }
+
+    //Prevent power application effect from appearing for Invisible powers
+    @SpirePatch(clz = ApplyPowerAction.class, method = "update")
+    public static class RemoveApplicationEffectsForInvisiblePowers {
+        @SpireInsertPatch(locator = Locator.class)
+        public static void antiApplicationEffect(ApplyPowerAction __instance, AbstractPower ___powerToApply) {
+            if (___powerToApply instanceof InvisiblePower) {
+                for (int i = AbstractDungeon.effectList.size() - 1; i > -1; i--) {
+                    if (___powerToApply.type == AbstractPower.PowerType.DEBUFF) {
+                        if (AbstractDungeon.effectList.get(i) instanceof PowerDebuffEffect) {
+                            AbstractDungeon.effectList.remove(i);
+                        }
+                    } else if (___powerToApply.type == AbstractPower.PowerType.BUFF) {
+                        if (AbstractDungeon.effectList.get(i) instanceof PowerBuffEffect) {
+                            AbstractDungeon.effectList.remove(i);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            @Override
+            public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+                Matcher finalMatcher = new Matcher.MethodCallMatcher(AbstractDungeon.class, "onModifyPower");
+                return LineFinder.findAllInOrder(ctMethodToPatch, finalMatcher);
+            }
+        }
+
+        @SpireInstrumentPatch
+        public static ExprEditor DontFlashInvisiblePowers() {
+            return new ExprEditor() {
+                @Override
+                public void edit(MethodCall m) throws CannotCompileException {
+                    if (m.getClassName().equals(AbstractPower.class.getName()) && m.getMethodName().equals("flash")) {
+                        m.replace("if (!(powerToApply instanceof " + InvisiblePower.class.getName() + ")) {" +
+                                "$_ = $proceed($$);" +
+                                "}");
                     }
                 }
             };


### PR DESCRIPTION
Why do invisible powers need images and notify players when they're being applied. 

This removes the power application effect and power flash when an invisible power is applied.