### PR TITLE
Fixed issue where normal Branching upgrades were random instead

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/cardInterfaces/BranchingUpgradesPatch.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/cardInterfaces/BranchingUpgradesPatch.java
@@ -264,8 +264,12 @@ public class BranchingUpgradesPatch {
         )
         public static void Insert(GridCardSelectScreen __instance) {
             AbstractCard hoveredCard = getHoveredCard();
-            if (hoveredCard instanceof BranchingUpgradesCard && BranchSelectFields.isBranchUpgrading.get(__instance)) {
-                ((BranchingUpgradesCard) hoveredCard).setUpgradeType(BranchingUpgradesCard.UpgradeType.BRANCH_UPGRADE);
+            if (hoveredCard instanceof BranchingUpgradesCard) {
+                if (BranchSelectFields.isBranchUpgrading.get(__instance)) {
+                    ((BranchingUpgradesCard) hoveredCard).setUpgradeType(BranchingUpgradesCard.UpgradeType.BRANCH_UPGRADE);
+                } else {
+                    ((BranchingUpgradesCard) hoveredCard).setUpgradeType(BranchingUpgradesCard.UpgradeType.NORMAL_UPGRADE);
+                }
                 BranchSelectFields.isBranchUpgrading.set(__instance, false);
             }
         }


### PR DESCRIPTION
On the confirmation of a branching upgrade, we changed RANDOM_UPGRADE to BRANCH_UPGRADE if we chose the branching one, but we were not changing RANDOM_UPGRADE to NORMAL_UPGRADE if we chose the normal one.