### PR TITLE
Added SpawnModificationCard interface and patch

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/cards/interfaces/SpawnModificationCard.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/cards/interfaces/SpawnModificationCard.java
@@ -18,12 +18,11 @@ public interface SpawnModificationCard {
 
     /**
      * If the card is rolled and passes its canSpawn check, you can return a new card instance that gets spawned instead.
-     * @param originalCard The card that was rolled.
      * @param currentRewardCards List of the cards that have already been rolled and accepted.
      * @return The instance of the card that will be checked against currentRewardCards to see whether it's already in there, if not, the card gets added to it.
      */
-    default AbstractCard replaceWith(AbstractCard originalCard, ArrayList<AbstractCard> currentRewardCards) {
-        return originalCard;
+    default AbstractCard replaceWith(ArrayList<AbstractCard> currentRewardCards) {
+        return (AbstractCard) this;
     }
 
     /**

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/cards/interfaces/SpawnModificationCard.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/cards/interfaces/SpawnModificationCard.java
@@ -1,0 +1,34 @@
+package com.evacipated.cardcrawl.mod.stslib.cards.interfaces;
+
+import com.megacrit.cardcrawl.cards.AbstractCard;
+
+import java.util.ArrayList;
+
+public interface SpawnModificationCard {
+    /**
+     * Get's called when the card is rolled and allows you to roll a new card.
+     * Note: Does not remove the card from the possible rolls, so it can be rolled again in the same reward.
+     * @param currentRewardCards List of the cards that have already been rolled and accepted.
+     * @return If true, the card will be checked against currentRewardCards to see whether it's already in there, if not, the card gets added to it.
+     *          If false, will be rerolled.
+     */
+    default boolean canSpawn(ArrayList<AbstractCard> currentRewardCards) {
+        return true;
+    }
+
+    /**
+     * If the card is rolled and passes its canSpawn check, you can return a new card instance that gets spawned instead.
+     * @param originalCard The card that was rolled.
+     * @param currentRewardCards List of the cards that have already been rolled and accepted.
+     * @return The instance of the card that will be checked against currentRewardCards to see whether it's already in there, if not, the card gets added to it.
+     */
+    default AbstractCard replaceWith(AbstractCard originalCard, ArrayList<AbstractCard> currentRewardCards) {
+        return originalCard;
+    }
+
+    /**
+     * Hook for final modifications once the card reward generation is over.
+     * @param rewardCards The arraylist of the cards that would show up in the card reward.
+     */
+    default void onRewardListCreated(ArrayList<AbstractCard> rewardCards) {}
+}

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/cardInterfaces/CardSpawnModificationPatch.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/cardInterfaces/CardSpawnModificationPatch.java
@@ -1,0 +1,43 @@
+package com.evacipated.cardcrawl.mod.stslib.patches.cardInterfaces;
+
+import com.evacipated.cardcrawl.mod.stslib.cards.interfaces.SpawnModificationCard;
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+import javassist.CtBehavior;
+
+import java.util.ArrayList;
+
+@SpirePatch2(clz = AbstractDungeon.class, method = "getRewardCards")
+public class CardSpawnModificationPatch {
+    //Patches into 1838 |  if (c.cardID.equals(card.cardID))
+    @SpireInsertPatch(locator = Locator.class, localvars = {"c", "containsDupe", "retVal"})
+    public static void patch(@ByRef AbstractCard[] c, @ByRef boolean[] containsDupe, ArrayList<AbstractCard> retVal) {
+        if(c[0] instanceof SpawnModificationCard) {
+            if(!((SpawnModificationCard) c[0]).canSpawn(retVal)) {
+                containsDupe[0] = true;
+                return;
+            }
+
+            c[0] = ((SpawnModificationCard) c[0]).replaceWith(c[0], retVal);
+        }
+    }
+
+    @SpirePostfixPatch
+    public static void patch(ArrayList<AbstractCard> __result) {
+        for(AbstractCard c : __result) {
+            if(c instanceof SpawnModificationCard) {
+                ((SpawnModificationCard) c).onRewardListCreated(__result);
+            }
+        }
+    }
+
+    private static class Locator extends SpireInsertLocator {
+        @Override
+        public int[] Locate(CtBehavior ctBehavior) throws Exception {
+            Matcher finalMatcher = new Matcher.MethodCallMatcher(String.class, "equals");
+            return LineFinder.findInOrder(ctBehavior, new ArrayList<>(), finalMatcher);
+        }
+    }
+}


### PR DESCRIPTION
This interface gives cards that implement it 3 overrideable methods.
canSpawn, replaceWith, onRewardListCreated

These essentially allow the player to fully customize how and if a card will be spawned and what happens if it does. 