### PR TITLE
modifying custom targeting code

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/cards/targeting/SelfOrEnemyTargeting.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/cards/targeting/SelfOrEnemyTargeting.java
@@ -3,9 +3,8 @@ package com.evacipated.cardcrawl.mod.stslib.cards.targeting;
 import basemod.ReflectionHacks;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.evacipated.cardcrawl.mod.stslib.patches.CustomTargeting;
 import com.evacipated.cardcrawl.modthespire.lib.SpireEnum;
-import com.evacipated.cardcrawl.modthespire.lib.SpireField;
-import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.AbstractCreature;
@@ -18,27 +17,15 @@ import com.megacrit.cardcrawl.monsters.AbstractMonster;
 
 import java.util.ArrayList;
 
-public class SelfOrEnemyTargeting extends TargetingHandler {
+public class SelfOrEnemyTargeting extends TargetingHandler<AbstractCreature> {
     @SpireEnum
     public static AbstractCard.CardTarget SELF_OR_ENEMY;
 
-    @SpirePatch(
-            clz = AbstractCard.class,
-            method = SpirePatch.CLASS
-    )
-    public static class Field {
-        public static SpireField<AbstractCreature> target = new SpireField<>(()->null);
-    }
     public static AbstractCreature getTarget(AbstractCard card) {
-        return Field.target.get(card);
+        return CustomTargeting.getCardTarget(card);
     }
 
     private AbstractCreature hovered = null;
-
-    @Override
-    public void lockTarget(AbstractCard card) {
-        Field.target.set(card, hovered);
-    }
 
     @Override
     public boolean hasTarget() {
@@ -64,6 +51,11 @@ public class SelfOrEnemyTargeting extends TargetingHandler {
                 }
             }
         }
+    }
+
+    @Override
+    public AbstractCreature getHovered() {
+        return hovered;
     }
 
     @Override

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/cards/targeting/TargetingHandler.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/cards/targeting/TargetingHandler.java
@@ -1,25 +1,37 @@
 package com.evacipated.cardcrawl.mod.stslib.cards.targeting;
 
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.evacipated.cardcrawl.mod.stslib.patches.CustomTargeting;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.helpers.input.InputHelper;
 
-public abstract class TargetingHandler {
+public abstract class TargetingHandler<T> {
     /* Assigns the current target to a card.
      * Can be stored in a SpireField on the card, or if this targeting is exclusively for your own cards, you could store it in your card class.
-     * After this, you just need to access it from wherever it is stored in the use method.
+     * After this, you just need to access it in the use method.
      */
-    public abstract void lockTarget(AbstractCard c);
+    public void lockTarget(AbstractCard card) {
+        T target = getHovered();
+        if (isValidTarget(target)) {
+            CustomTargeting.setCardTarget(card, getHovered());
+        }
+        else {
+            CustomTargeting.setCardTarget(card, null);
+        }
+    }
 
     public abstract void updateHovered(); //Update/check what valid target is currently hovered
+    public abstract T getHovered(); //Get currently hovered target.
     public abstract void clearHovered(); //Clear current target when leaving targeting mode
     public abstract boolean hasTarget(); //Whether a valid target is hovered
+    public boolean isValidTarget(T target) { //Used for things like double play to ensure the target is still valid.
+        return true;
+    }
 
     //Render reticle on the current target
     public void renderReticle(SpriteBatch sb) {
     }
-
 
     //Update keyboard targeting logic. Optional to implement.
     public void updateKeyboardTarget() {


### PR DESCRIPTION
Allows it to work properly with double play effects, as well as making it possible to more generally access a card's custom target(s), and also theoretically reducing how much you need to do to implement it.
This *will* break any custom targeting things already made by others, but for some reason I feel like there aren't any.
Well, it's an easy fix.