### PR TITLE
Update icons to use new energy orb render code

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/icons/AbstractCustomIcon.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/icons/AbstractCustomIcon.java
@@ -1,9 +1,12 @@
 package com.evacipated.cardcrawl.mod.stslib.icons;
 
+import basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard.ShrinkLongDescription;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas.AtlasRegion;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.core.Settings;
 
 public abstract class AbstractCustomIcon {
     public static final int RENDER_CONSTANT = 24;
@@ -32,6 +35,10 @@ public abstract class AbstractCustomIcon {
         return (float) RENDER_CONSTANT / getImgSize();
     }
 
+    public float getCardRenderScale(AbstractCard card) {
+        return getRenderScale() * ShrinkLongDescription.Scale.descriptionScale.get(card);
+    }
+
     public void render(SpriteBatch sb, float drawX, float drawY, float offsetX, float offsetY, float scale, float angle) {
         Color backup = sb.getColor();
         sb.setColor(new Color(1.0F, 1.0F, 1.0F, backup.a));
@@ -40,5 +47,33 @@ public abstract class AbstractCustomIcon {
                 (float) region.packedWidth, (float) region.packedHeight,
                 scale * getRenderScale(), scale * getRenderScale(), angle);
         sb.setColor(backup);
+    }
+
+    public void renderOnCard(SpriteBatch sb, AbstractCard card, float x, float y) {
+        x /= getRenderScale();
+        y /= getRenderScale();
+        Color backup = sb.getColor();
+        sb.setColor(new Color(1.0F, 1.0F, 1.0F, backup.a));
+        sb.draw(region.getTexture(), card.current_x + x + region.offsetX, card.current_y + y + region.offsetY,
+                -x - region.offsetX, -y - region.offsetY,
+                (float)region.packedWidth, (float)region.packedHeight,
+                card.drawScale * Settings.scale * getRenderScale() * ShrinkLongDescription.Scale.descriptionScale.get(card), card.drawScale * Settings.scale * getRenderScale() * ShrinkLongDescription.Scale.descriptionScale.get(card),
+                card.angle, region.getRegionX(), region.getRegionY(), region.getRegionWidth(), region.getRegionHeight(), false, false);
+        sb.setColor(backup);
+
+    }
+
+    public void renderOnSCV(SpriteBatch sb, AbstractCard card, float x, float y, float current_x, float current_y, float scale) {
+        x /= getRenderScale();
+        y /= getRenderScale();
+        Color backup = sb.getColor();
+        sb.setColor(new Color(1.0F, 1.0F, 1.0F, backup.a));
+        sb.draw(region.getTexture(), current_x + x + region.offsetX, current_y + y + region.offsetY,
+                -x - region.offsetX, -y - region.offsetY,
+                (float)region.packedWidth, (float)region.packedHeight,
+                scale * Settings.scale * getRenderScale() * ShrinkLongDescription.Scale.descriptionScale.get(card), scale * Settings.scale * getRenderScale() * ShrinkLongDescription.Scale.descriptionScale.get(card),
+                card.angle, region.getRegionX(), region.getRegionY(), region.getRegionWidth(), region.getRegionHeight(), false, false);
+        sb.setColor(backup);
+
     }
 }

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/CardDescriptionCustomIcons.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/CardDescriptionCustomIcons.java
@@ -1,5 +1,6 @@
 package com.evacipated.cardcrawl.mod.stslib.patches;
 
+import basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard.ShrinkLongDescription;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
@@ -32,18 +33,14 @@ public class CardDescriptionCustomIcons {
                 }
                 AbstractCustomIcon icon = CustomIconHelper.getIcon(key);
                 if (icon != null) {
-                    gl.width = CARD_ENERGY_IMG_WIDTH * __instance.drawScale;
+                    gl.width = CARD_ENERGY_IMG_WIDTH * __instance.drawScale * ShrinkLongDescription.Scale.descriptionScale.get(__instance);
                     renderSmallIcon(__instance, sb, icon,
-                            (start_x[0] - __instance.current_x) / Settings.scale / __instance.drawScale,
-                            (-98.0f - ((__instance.description.size() - 4.0f) / 2.0f - i + 1.0f) * spacing));
+                            (start_x[0] - __instance.current_x) / Settings.scale / __instance.drawScale / ShrinkLongDescription.Scale.descriptionScale.get(__instance),
+                            (draw_y + i * 1.45f * -font.getCapHeight() - 6f - __instance.current_y + font.getCapHeight()) / Settings.scale / __instance.drawScale / ShrinkLongDescription.Scale.descriptionScale.get(__instance) - 26);
                     start_x[0] += gl.width;
                     tmp[0] = "";
                 }
             }
-        }
-
-        public static void renderSmallIcon(AbstractCard card, SpriteBatch sb, AbstractCustomIcon icon, float offsetX, float offsetY) {
-            icon.render(sb, card.current_x + offsetX * Settings.scale * card.drawScale, card.current_y + offsetY * Settings.scale * card.drawScale, icon.region.getRegionWidth()/2F, icon.region.getRegionWidth()/2F, Settings.scale * card.drawScale, card.angle);
         }
 
         private static class Locator extends SpireInsertLocator {
@@ -57,11 +54,15 @@ public class CardDescriptionCustomIcons {
         }
     }
 
+    public static void renderSmallIcon(AbstractCard card, SpriteBatch sb, AbstractCustomIcon icon, float offsetX, float offsetY) {
+        icon.renderOnCard(sb, card, offsetX, offsetY);
+    }
+
     @SpirePatch(clz=SingleCardViewPopup.class, method="renderDescription")
     @SpirePatch(clz=SingleCardViewPopup.class, method="renderDescriptionCN")
     public static class RenderSmallIconSingleCardView {
-        @SpireInsertPatch(locator=Locator.class, localvars={"spacing", "i", "start_x", "tmp", "gl", "card_energy_w", "drawScale", "current_x", "current_y", "card"})
-        public static void Insert(SingleCardViewPopup __instance, SpriteBatch sb, float spacing, int i, @ByRef float[] start_x, @ByRef String[] tmp, GlyphLayout gl, float card_energy_w, float drawScale, float current_x, float current_y, AbstractCard card) {
+        @SpireInsertPatch(locator=Locator.class, localvars={"spacing", "i", "start_x", "draw_y", "tmp", "gl", "card_energy_w", "drawScale", "current_x", "current_y", "card", "font"})
+        public static void Insert(SingleCardViewPopup __instance, SpriteBatch sb, float spacing, int i, @ByRef float[] start_x, float draw_y, @ByRef String[] tmp, GlyphLayout gl, float card_energy_w, float drawScale, float current_x, float current_y, AbstractCard card, BitmapFont font) {
             if (tmp[0].length() > 0 && tmp[0].charAt(0) == '[') {
                 String key = tmp[0].trim();
                 if (key.endsWith(AbstractCustomIcon.CODE_ENDING)) {
@@ -69,9 +70,11 @@ public class CardDescriptionCustomIcons {
                 }
                 AbstractCustomIcon icon = CustomIconHelper.getIcon(key);
                 if (icon != null) {
-                    gl.width = card_energy_w * drawScale;
-                    //icon.render(sb, current_x, current_y, start_x[0] - current_x, -86.0f - ((card.description.size() - 4.0f) / 2.0f - i + 1.0f) * spacing, drawScale * Settings.scale, card.angle);
-                    renderSCVIcon(sb, icon, (start_x[0] - current_x) / Settings.scale / drawScale, -86.0f - ((card.description.size() - 4.0f) / 2.0f - i + 1.0f) * spacing, drawScale, current_x, current_y);
+                    gl.width = card_energy_w * drawScale * ShrinkLongDescription.Scale.descriptionScale.get(card);
+                    renderSCVIcon(card, sb, icon,
+                            (start_x[0] - current_x) / Settings.scale / drawScale / ShrinkLongDescription.Scale.descriptionScale.get(card),
+                            (draw_y + (float)i * 1.53F * -font.getCapHeight() - 12f - current_y - font.getCapHeight()/2f) / Settings.scale / drawScale / ShrinkLongDescription.Scale.descriptionScale.get(card),
+                            drawScale, current_x, current_y);
                     start_x[0] += gl.width;
                     tmp[0] = "";
                 }
@@ -88,8 +91,10 @@ public class CardDescriptionCustomIcons {
         }
     }
 
-    public static void renderSCVIcon(SpriteBatch sb, AbstractCustomIcon icon, float x, float y, float scale, float cx, float cy) {
-        icon.render(sb, cx + x * Settings.scale * scale + icon.region.offsetX * Settings.scale - 4.0F * Settings.scale, cy + y * Settings.scale * scale + 280.0F * Settings.scale, icon.region.getRegionWidth()/2F, icon.region.getRegionWidth()/2F, scale * Settings.scale, 0);
+    public static void renderSCVIcon(AbstractCard card, SpriteBatch sb, AbstractCustomIcon icon, float x, float y, float scale, float cx, float cy) {
+        //icon.render(sb, x, y, cx, cy, scale * Settings.scale * ShrinkLongDescription.Scale.descriptionScale.get(card), 0);
+        icon.renderOnSCV(sb, card, x, y, cx, cy, scale);
+        //icon.render(sb, cx + x * Settings.scale * scale + icon.region.offsetX * Settings.scale - 4.0F * Settings.scale, cy + y * Settings.scale * scale + 280.0F * Settings.scale, icon.region.getRegionWidth()/2F, icon.region.getRegionWidth()/2F, scale * Settings.scale, 0);
     }
 
     @SpirePatch(clz=AbstractCard.class, method="initializeDescription")


### PR DESCRIPTION
Icons now have proper rendering on angled cards, and will scale in accordance with ShrinkDescriptionSize.