### PR TITLE
Add support for custom tooltips linked to card text icons

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/icons/AbstractCustomIcon.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/icons/AbstractCustomIcon.java
@@ -1,5 +1,6 @@
 package com.evacipated.cardcrawl.mod.stslib.icons;
 
+import basemod.helpers.TooltipInfo;
 import basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard.ShrinkLongDescription;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
@@ -7,6 +8,9 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas.AtlasRegion;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.Settings;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public abstract class AbstractCustomIcon {
     public static final int RENDER_CONSTANT = 24;
@@ -37,6 +41,10 @@ public abstract class AbstractCustomIcon {
 
     public float getCardRenderScale(AbstractCard card) {
         return getRenderScale() * ShrinkLongDescription.Scale.descriptionScale.get(card);
+    }
+
+    public List<TooltipInfo> getCustomTooltips() {
+        return new ArrayList<>();
     }
 
     public void render(SpriteBatch sb, float drawX, float drawY, float offsetX, float offsetY, float scale, float angle) {

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/icons/AbstractCustomIcon.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/icons/AbstractCustomIcon.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas.AtlasRegion;
+import com.evacipated.cardcrawl.mod.stslib.Keyword;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.Settings;
 
@@ -44,6 +45,10 @@ public abstract class AbstractCustomIcon {
     }
 
     public List<TooltipInfo> getCustomTooltips() {
+        return new ArrayList<>();
+    }
+
+    public List<String> keywordLinks() {
         return new ArrayList<>();
     }
 

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/icons/CustomIconHelper.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/icons/CustomIconHelper.java
@@ -1,5 +1,8 @@
 package com.evacipated.cardcrawl.mod.stslib.icons;
 
+import com.megacrit.cardcrawl.cards.AbstractCard;
+
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 
@@ -16,5 +19,15 @@ public class CustomIconHelper {
 
     public static Collection<AbstractCustomIcon> getAllIcons() {
         return icons.values();
+    }
+
+    public static ArrayList<AbstractCustomIcon> iconsOnCard(AbstractCard card) {
+        ArrayList<AbstractCustomIcon> icons = new ArrayList<>();
+        for (AbstractCustomIcon i : getAllIcons()) {
+            if (card.rawDescription.contains(i.cardCode())) {
+                icons.add(i);
+            }
+        }
+        return icons;
     }
 }

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/DescriptorAndTooltipPatches.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/DescriptorAndTooltipPatches.java
@@ -1,5 +1,6 @@
 package com.evacipated.cardcrawl.mod.stslib.patches;
 
+import basemod.BaseMod;
 import basemod.abstracts.CustomCard;
 import basemod.helpers.TooltipInfo;
 import basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard.RenderCardDescriptors;
@@ -41,6 +42,13 @@ public class DescriptorAndTooltipPatches {
                 }
             }
             for (AbstractCustomIcon icon : CustomIconHelper.iconsOnCard(___card)) {
+                if (icon.keywordLinks() != null) {
+                    for (String s : icon.keywordLinks()) {
+                        if (!___card.rawDescription.toLowerCase().contains(s)) {
+                            tooltips[0].add(new TooltipInfo(BaseMod.getKeywordTitle(s), BaseMod.getKeywordDescription(s)));
+                        }
+                    }
+                }
                 if (icon.getCustomTooltips() != null) {
                     tooltips[0].addAll(icon.getCustomTooltips());
                 }
@@ -78,6 +86,13 @@ public class DescriptorAndTooltipPatches {
                 tooltips[0].addAll(mod.getCustomTooltips());
             }
             for (AbstractCustomIcon icon : CustomIconHelper.iconsOnCard(___card)) {
+                if (icon.keywordLinks() != null) {
+                    for (String s : icon.keywordLinks()) {
+                        if (!___card.rawDescription.toLowerCase().contains(s)) {
+                            tooltips[0].add(new TooltipInfo(BaseMod.getKeywordTitle(s), BaseMod.getKeywordDescription(s)));
+                        }
+                    }
+                }
                 if (icon.getCustomTooltips() != null) {
                     tooltips[0].addAll(icon.getCustomTooltips());
                 }
@@ -128,6 +143,13 @@ public class DescriptorAndTooltipPatches {
                 }
             }
             for (AbstractCustomIcon icon : CustomIconHelper.iconsOnCard(acard)) {
+                if (icon.keywordLinks() != null) {
+                    for (String s : icon.keywordLinks()) {
+                        if (!acard.rawDescription.toLowerCase().contains(s)) {
+                            t[0].add(new TooltipInfo(BaseMod.getKeywordTitle(s), BaseMod.getKeywordDescription(s)).toPowerTip());
+                        }
+                    }
+                }
                 if (icon.getCustomTooltips() != null) {
                     for (TooltipInfo tip : icon.getCustomTooltips()) {
                         t[0].add(tip.toPowerTip());

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/DescriptorAndTooltipPatches.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/DescriptorAndTooltipPatches.java
@@ -9,6 +9,8 @@ import com.evacipated.cardcrawl.mod.stslib.blockmods.AbstractBlockModifier;
 import com.evacipated.cardcrawl.mod.stslib.blockmods.BlockModifierManager;
 import com.evacipated.cardcrawl.mod.stslib.damagemods.AbstractDamageModifier;
 import com.evacipated.cardcrawl.mod.stslib.damagemods.DamageModifierManager;
+import com.evacipated.cardcrawl.mod.stslib.icons.AbstractCustomIcon;
+import com.evacipated.cardcrawl.mod.stslib.icons.CustomIconHelper;
 import com.evacipated.cardcrawl.mod.stslib.powers.interfaces.DamageModApplyingPower;
 import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.megacrit.cardcrawl.cards.AbstractCard;
@@ -38,6 +40,11 @@ public class DescriptorAndTooltipPatches {
                     tooltips[0].addAll(mod.getCustomTooltips());
                 }
             }
+            for (AbstractCustomIcon icon : CustomIconHelper.iconsOnCard(___card)) {
+                if (icon.getCustomTooltips() != null) {
+                    tooltips[0].addAll(icon.getCustomTooltips());
+                }
+            }
             if (AbstractDungeon.player != null && RenderElementsOnCardPatches.validLocation(___card)) {
                 for (AbstractPower p : AbstractDungeon.player.powers) {
                     if (p instanceof DamageModApplyingPower && ((DamageModApplyingPower) p).shouldPushMods(null, ___card, DamageModifierManager.modifiers(___card))) {
@@ -50,6 +57,7 @@ public class DescriptorAndTooltipPatches {
                 }
             }
         }
+
         private static class Locator1 extends SpireInsertLocator {
             @Override
             public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
@@ -69,6 +77,11 @@ public class DescriptorAndTooltipPatches {
             for (AbstractBlockModifier mod : BlockModifierManager.modifiers(___card)) {
                 tooltips[0].addAll(mod.getCustomTooltips());
             }
+            for (AbstractCustomIcon icon : CustomIconHelper.iconsOnCard(___card)) {
+                if (icon.getCustomTooltips() != null) {
+                    tooltips[0].addAll(icon.getCustomTooltips());
+                }
+            }
             if (AbstractDungeon.player != null && RenderElementsOnCardPatches.validLocation(___card)) {
                 for (AbstractPower p : AbstractDungeon.player.powers) {
                     if (p instanceof DamageModApplyingPower && ((DamageModApplyingPower) p).shouldPushMods(null, ___card, DamageModifierManager.modifiers(___card))) {
@@ -81,6 +94,7 @@ public class DescriptorAndTooltipPatches {
                 }
             }
         }
+
         private static class Locator2 extends SpireInsertLocator {
             @Override
             public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
@@ -88,7 +102,7 @@ public class DescriptorAndTooltipPatches {
                 int[] tmp = LineFinder.findAllInOrder(ctMethodToPatch, finalMatcher);
                 int[] ret = new int[1];
                 for (int value : tmp) {
-                    ret[0] = value-1;
+                    ret[0] = value - 1;
                 }
                 return ret;
             }
@@ -109,6 +123,13 @@ public class DescriptorAndTooltipPatches {
             for (AbstractBlockModifier mod : BlockModifierManager.modifiers(acard)) {
                 if (mod.getCustomTooltips() != null) {
                     for (TooltipInfo tip : mod.getCustomTooltips()) {
+                        t[0].add(tip.toPowerTip());
+                    }
+                }
+            }
+            for (AbstractCustomIcon icon : CustomIconHelper.iconsOnCard(acard)) {
+                if (icon.getCustomTooltips() != null) {
+                    for (TooltipInfo tip : icon.getCustomTooltips()) {
                         t[0].add(tip.toPowerTip());
                     }
                 }
@@ -144,6 +165,7 @@ public class DescriptorAndTooltipPatches {
                 }
             }
         }
+
         private static class Locator extends SpireInsertLocator {
             @Override
             public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
@@ -168,6 +190,7 @@ public class DescriptorAndTooltipPatches {
                 }
             }
         }
+
         private static class Locator extends SpireInsertLocator {
             @Override
             public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
@@ -192,6 +215,7 @@ public class DescriptorAndTooltipPatches {
                 }
             }
         }
+
         private static class Locator extends SpireInsertLocator {
             @Override
             public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {


### PR DESCRIPTION
This lets cards which reference a keyword only via icon still show tooltips with that keyword, as one example.

![image](https://user-images.githubusercontent.com/19942951/202886753-bd19e17b-9868-4b0c-9e73-f655e76460dc.png)
