### PR TITLE
Adding CardRewardSkipButtonRelic interface

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/relicInterfaces/CardRewardSkipButtonPatches.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/relicInterfaces/CardRewardSkipButtonPatches.java
@@ -1,0 +1,106 @@
+package com.evacipated.cardcrawl.mod.stslib.patches.relicInterfaces;
+
+import basemod.BaseMod;
+import basemod.ReflectionHacks;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.evacipated.cardcrawl.mod.stslib.relics.CardRewardSkipButton;
+import com.evacipated.cardcrawl.mod.stslib.relics.CardRewardSkipButtonRelic;
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch2;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.ImageMaster;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+import com.megacrit.cardcrawl.screens.CardRewardScreen;
+import sun.security.util.AuthResources_zh_CN;
+
+import java.util.ArrayList;
+
+public class CardRewardSkipButtonPatches {
+
+    private static boolean showButtons(CardRewardScreen screen) {
+        boolean draft = ReflectionHacks.getPrivate(screen, CardRewardScreen.class, "draft");
+        boolean codex = ReflectionHacks.getPrivate(screen, CardRewardScreen.class, "codex");
+        boolean discovery = ReflectionHacks.getPrivate(screen, CardRewardScreen.class, "discovery");
+        boolean chooseOne = ReflectionHacks.getPrivate(screen, CardRewardScreen.class, "chooseOne");
+
+        return !draft && !codex && !discovery && !chooseOne;
+    }
+
+
+    private static void positionButtons(ArrayList<CardRewardSkipButton> buttons) {
+        ArrayList<Float> Xs = new ArrayList<>();
+        float trueWidth = ImageMaster.REWARD_SCREEN_TAKE_BUTTON.getWidth()* 0.6f;
+        float diffX = ImageMaster.REWARD_SCREEN_TAKE_BUTTON.getWidth() * 0.2f;
+        float Y = (float) Settings.HEIGHT / 2.0F - 340.0F * Settings.scale;
+        Y -= ImageMaster.REWARD_SCREEN_TAKE_BUTTON.getHeight() * 0.85f;
+        float pointerX = Settings.WIDTH/2f - diffX;
+        float totalWidth = 0;
+        for (CardRewardSkipButton button : buttons) {
+            Xs.add(pointerX);
+            button.move(pointerX, Y);
+            pointerX += trueWidth;
+            totalWidth += trueWidth;
+        }
+        for (CardRewardSkipButton button : buttons) {
+            button.setX(Xs.get(buttons.indexOf(button)) - totalWidth/2f);
+        }
+    }
+
+    @SpirePatch(clz = CardRewardScreen.class, method = SpirePatch.CLASS)
+    public static class ButtonsField {
+        public static SpireField<ArrayList<CardRewardSkipButton>> buttons = new SpireField<>(ArrayList::new);
+    }
+
+
+    @SpirePatch2(clz = CardRewardScreen.class, method = "open")
+    public static class OpenPatch {
+
+        @SpirePostfixPatch
+        public static void addButtons(CardRewardScreen __instance) {
+            ButtonsField.buttons.get(__instance).clear();
+            if (showButtons(__instance)) {
+                for (AbstractRelic r : AbstractDungeon.player.relics) {
+                    if (r instanceof CardRewardSkipButtonRelic) {
+                        CardRewardSkipButtonRelic bR = (CardRewardSkipButtonRelic)r;
+                        CardRewardSkipButton button = new CardRewardSkipButton(bR);
+                        ButtonsField.buttons.get(__instance).add(button);
+                    }
+                }
+                BaseMod.logger.info("======== Adding" + ButtonsField.buttons.get(__instance).size() + " buttons");
+                positionButtons(ButtonsField.buttons.get(__instance));
+            }
+        }
+    }
+
+
+
+    @SpirePatch2(clz = CardRewardScreen.class, method = "update")
+    public static class UpdatePatch {
+
+        @SpirePostfixPatch
+        public static void updateButtons(CardRewardScreen __instance) {
+            if (showButtons(__instance)) {
+                for (CardRewardSkipButton button : ButtonsField.buttons.get(__instance)) {
+                    button.update();
+                }
+            }
+        }
+    }
+
+    @SpirePatch2(clz = CardRewardScreen.class, method = "render")
+    public static class RenderPatch {
+
+        @SpirePostfixPatch
+        public static void renderButtons(CardRewardScreen __instance, SpriteBatch sb) {
+            if (showButtons(__instance)) {
+                for (CardRewardSkipButton button : ButtonsField.buttons.get(__instance)) {
+                    button.render(sb);
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/relicInterfaces/CardRewardSkipButtonPatches.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/relicInterfaces/CardRewardSkipButtonPatches.java
@@ -14,7 +14,6 @@ import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.ImageMaster;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
 import com.megacrit.cardcrawl.screens.CardRewardScreen;
-import sun.security.util.AuthResources_zh_CN;
 
 import java.util.ArrayList;
 
@@ -69,7 +68,6 @@ public class CardRewardSkipButtonPatches {
                         ButtonsField.buttons.get(__instance).add(button);
                     }
                 }
-                BaseMod.logger.info("======== Adding" + ButtonsField.buttons.get(__instance).size() + " buttons");
                 positionButtons(ButtonsField.buttons.get(__instance));
             }
         }

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/relics/CardRewardSkipButton.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/relics/CardRewardSkipButton.java
@@ -84,7 +84,7 @@ public class CardRewardSkipButton extends ClickableUIElement {
 
         float textX = x + relic.getTexture().getWidth()/2f;
         float textY = y + relic.getTexture().getHeight()/2f;
-        FontHelper.renderFontCentered(sb, FontHelper.buttonLabelFont, label, textX, textY, Color.WHITE, 0.8F);
+        FontHelper.renderFontCentered(sb, FontHelper.buttonLabelFont, label, textX, textY, Color.WHITE, 1F);
         renderHitbox(sb);
     }
 

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/relics/CardRewardSkipButton.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/relics/CardRewardSkipButton.java
@@ -1,0 +1,92 @@
+package com.evacipated.cardcrawl.mod.stslib.relics;
+
+import basemod.ClickableUIElement;
+import basemod.ReflectionHacks;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.FontHelper;
+import com.megacrit.cardcrawl.helpers.Hitbox;
+import com.megacrit.cardcrawl.helpers.ImageMaster;
+import com.megacrit.cardcrawl.screens.CardRewardScreen;
+
+public class CardRewardSkipButton extends ClickableUIElement {
+
+    private static final float HITBOX_OFFSET_X = ImageMaster.REWARD_SCREEN_TAKE_BUTTON.getWidth() * 0.2f;
+    private static final float HITBOX_OFFSET_Y = ImageMaster.REWARD_SCREEN_TAKE_BUTTON.getHeight() * 0.3f;
+
+    private final CardRewardSkipButtonRelic relic;
+
+    private final String label;
+
+    boolean lighten = false;
+
+
+    public CardRewardSkipButton(CardRewardSkipButtonRelic relic) {
+        super(relic.getTexture(), 0, 0, ImageMaster.REWARD_SCREEN_TAKE_BUTTON.getWidth()*0.6f,ImageMaster.REWARD_SCREEN_TAKE_BUTTON.getHeight()*0.4f);
+        this.relic = relic;
+        label = relic.getButtonLabel();
+        this.hitbox = new Hitbox(hb_w, hb_h);
+
+    }
+
+    @Override
+    protected void onHover() {
+        if (hitbox.justHovered) CardCrawlGame.sound.play("UI_HOVER");
+        lighten = true;
+    }
+
+    @Override
+    protected void onUnhover() {
+        lighten = false;
+    }
+
+    @Override
+    protected void onClick() {
+        relic.onClickedButton();
+        closeReward();
+    }
+
+    private void closeReward() {
+        ReflectionHacks.privateMethod(CardRewardScreen.class, "takeReward").invoke(AbstractDungeon.cardRewardScreen);
+        AbstractDungeon.closeCurrentScreen();
+    }
+
+    public void move(float newX, float newY) {
+        setX(newX);
+        setY(newY);
+    }
+
+    @Override
+    public void setX(float x) {
+        this.x = x;
+        hitbox.x = x + HITBOX_OFFSET_X;
+    }
+
+    @Override
+    public void setY(float y) {
+        this.y = y;
+        hitbox.y = y + HITBOX_OFFSET_Y;
+    }
+
+    public void render(SpriteBatch sb) {
+        sb.setColor(Color.WHITE);
+        sb.draw(relic.getTexture(), x, y);
+        if (lighten) {
+            sb.setBlendFunction(770, 1);
+            sb.setColor(new Color(1f,1f,1f,0.3f));
+            sb.draw(relic.getTexture(),x , y);
+            sb.setBlendFunction(770, 771);
+        }
+
+        float textX = x + relic.getTexture().getWidth()/2f;
+        float textY = y + relic.getTexture().getHeight()/2f;
+        FontHelper.renderFontCentered(sb, FontHelper.buttonLabelFont, label, textX, textY, Color.WHITE, 0.8F);
+        renderHitbox(sb);
+    }
+
+
+}

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/relics/CardRewardSkipButtonRelic.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/relics/CardRewardSkipButtonRelic.java
@@ -1,0 +1,4 @@
+package com.evacipated.cardcrawl.mod.stslib.relics;
+
+public class CardRewardSkipButtonRelic {
+}

--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/relics/CardRewardSkipButtonRelic.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/relics/CardRewardSkipButtonRelic.java
@@ -1,4 +1,16 @@
 package com.evacipated.cardcrawl.mod.stslib.relics;
 
-public class CardRewardSkipButtonRelic {
+import com.badlogic.gdx.graphics.Texture;
+import com.megacrit.cardcrawl.helpers.ImageMaster;
+
+public interface CardRewardSkipButtonRelic {
+
+    void onClickedButton();
+
+    String getButtonLabel();
+
+    default Texture getTexture() {
+        return ImageMaster.REWARD_SCREEN_TAKE_BUTTON;
+    }
+
 }


### PR DESCRIPTION
Adds an interface to add an effect similar to Singing Bowl's to relics. Option to have a custom texture for the button, but it needs to have the same size.