### PR TITLE
Add extra flavor text to relic

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/FlavorText.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/FlavorText.java
@@ -22,7 +22,9 @@ import com.megacrit.cardcrawl.helpers.TipHelper;
 import com.megacrit.cardcrawl.localization.CardStrings;
 import com.megacrit.cardcrawl.localization.LocalizedStrings;
 import com.megacrit.cardcrawl.localization.PotionStrings;
+import com.megacrit.cardcrawl.localization.RelicStrings;
 import com.megacrit.cardcrawl.potions.AbstractPotion;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
 import com.megacrit.cardcrawl.screens.SingleCardViewPopup;
 import javassist.CtBehavior;
 
@@ -115,6 +117,20 @@ public class FlavorText {
         public static SpireField<Texture> boxBot = new SpireField<>(() -> null);
     }
 
+    @SpirePatch2(
+            clz = AbstractRelic.class,
+            method = SpirePatch.CLASS
+    )
+    public static class RelicExtraFlavorFields {
+        public static SpireField<String> text = new SpireField<>(() -> null);
+        public static SpireField<Color> boxColor = new SpireField<>(Color.WHITE::cpy);
+        public static SpireField<Color> textColor = new SpireField<>(Color.BLACK::cpy);
+        public static SpireField<FlavorText.boxType> flavorBoxType = new SpireField<>(() -> FlavorText.boxType.WHITE);
+        public static SpireField<Texture> boxTop = new SpireField<>(() -> null);
+        public static SpireField<Texture> boxMid = new SpireField<>(() -> null);
+        public static SpireField<Texture> boxBot = new SpireField<>(() -> null);
+    }
+
     @SpirePatch(
             clz = CardStrings.class,
             method = SpirePatch.CLASS
@@ -131,6 +147,15 @@ public class FlavorText {
     public static class PotionStringsFlavorField {
         @SerializedName("FLAVOR")
         public static SpireField<String> flavor = new SpireField<>(() -> null);
+    }
+
+    @SpirePatch(
+            clz = RelicStrings.class,
+            method = SpirePatch.CLASS
+    )
+    public static class RelicStringsExtraFlavorField {
+        @SerializedName("EXTRA_FLAVOR")
+        public static SpireField<String> extraFlavor = new SpireField<>(() -> null);
     }
 
     @SpirePatch2(
@@ -172,6 +197,32 @@ public class FlavorText {
                 return;
 
             PotionFlavorFields.flavor.set(__instance, PotionStringsFlavorField.flavor.get(potionStrings));
+        }
+    }
+
+    @SpirePatch2(
+            clz = AbstractRelic.class,
+            method = SpirePatch.CONSTRUCTOR,
+            paramtypez = {String.class, String.class, AbstractRelic.RelicTier.class, AbstractRelic.LandingSound.class}
+    )
+    public static class FlavorIntoRelicStrings {
+        @SpireInsertPatch(
+                locator = Locator.class
+        )
+        public static void postfix(AbstractRelic __instance) {
+            RelicStrings relicStrings = CardCrawlGame.languagePack.getRelicStrings(__instance.relicId);
+            if (relicStrings == null || RelicStringsExtraFlavorField.extraFlavor.get(relicStrings) == null ||
+                    RelicStringsExtraFlavorField.extraFlavor.get(relicStrings).isEmpty())
+                return;
+
+            RelicExtraFlavorFields.text.set(__instance, RelicStringsExtraFlavorField.extraFlavor.get(relicStrings));
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+                Matcher finalMatcher = new Matcher.MethodCallMatcher(AbstractRelic.class, "initializeTips");
+                return LineFinder.findInOrder(ctMethodToPatch, new ArrayList<>(), finalMatcher);
+            }
         }
     }
 
@@ -230,6 +281,33 @@ public class FlavorText {
             PowerTipFlavorFields.boxMid.set(tip, PotionFlavorFields.boxMid.get(__instance));
             PowerTipFlavorFields.boxTop.set(tip, PotionFlavorFields.boxTop.get(__instance));
             __instance.tips.add(tip);
+        }
+    }
+
+    @SpirePatch2(
+            clz = AbstractRelic.class,
+            method = "renderTip"
+    )
+    public static class PassRelicTooltip {
+        @SpirePrefixPatch
+        public static SpireReturn<Void> Prefix(AbstractRelic __instance) {
+            if (__instance.tips.stream().anyMatch(tip -> tip.header.equals(HEADER_STRING)))
+                return SpireReturn.Continue();
+
+            if (RelicExtraFlavorFields.text.get(__instance) == null || RelicExtraFlavorFields.text.get(__instance) == null ||
+                    RelicExtraFlavorFields.text.get(__instance).isEmpty())
+                return SpireReturn.Continue();
+
+            PowerTip tip = new PowerTip(HEADER_STRING, RelicExtraFlavorFields.text.get(__instance));
+            FlavorText.PowerTipFlavorFields.textColor.set(tip, RelicExtraFlavorFields.textColor.get(__instance));
+            FlavorText.PowerTipFlavorFields.boxColor.set(tip, RelicExtraFlavorFields.boxColor.get(__instance));
+            FlavorText.PowerTipFlavorFields.flavorBoxType.set(tip, RelicExtraFlavorFields.flavorBoxType.get(__instance));
+            FlavorText.PowerTipFlavorFields.boxBot.set(tip, RelicExtraFlavorFields.boxBot.get(__instance));
+            FlavorText.PowerTipFlavorFields.boxMid.set(tip, RelicExtraFlavorFields.boxMid.get(__instance));
+            FlavorText.PowerTipFlavorFields.boxTop.set(tip, RelicExtraFlavorFields.boxTop.get(__instance));
+            __instance.tips.add(tip);
+
+            return SpireReturn.Continue();
         }
     }
 


### PR DESCRIPTION
Add "EXTRA_FLAVOR" string field to relics. This should act like the "FLAVOR" in cards and potions, which shows an extra power tip.

The field "EXTRA_FLAVOR" is useful when modder wants to show the origin of a meme, but the "FLAVOR" field of relics is already used to show the meme.