### PR TITLE
Add transfrom and upgrade preview in SelectCardsInHandAction

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/HandCardSelectCustomPreviewPatch.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/HandCardSelectCustomPreviewPatch.java
@@ -1,0 +1,30 @@
+package com.evacipated.cardcrawl.mod.stslib.patches;
+
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.screens.select.HandCardSelectScreen;
+
+import java.util.function.Function;
+
+public class HandCardSelectCustomPreviewPatch {
+    private static Function<AbstractCard, AbstractCard> customPreviewFunction = null;
+    private static AbstractCard cachedCard = null;
+    public static void setCustomPreviewFunction(Function<AbstractCard, AbstractCard> newFunction) {
+        customPreviewFunction = newFunction;
+        cachedCard = null;
+    }
+
+    @SpirePatch2(clz = HandCardSelectScreen.class, method = "update")
+    public static class ChangeUpgradeCard {
+        @SpirePostfixPatch
+        public static void Postfix(HandCardSelectScreen __instance) {
+            if (customPreviewFunction != null && __instance.numCardsToSelect == 1 && __instance.selectedCards.size() == 1) {
+                AbstractCard card = __instance.selectedCards.getTopCard();
+                if (cachedCard != card) {
+                    __instance.upgradePreviewCard = customPreviewFunction.apply(card.makeStatEquivalentCopy());
+                    cachedCard = card;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## The first commit

Add `forTransform` and `forUpgrade` parameters, which is used in `HandCardSelectScreen::open`.

The following is what happens If you set `forUpgrade` to `true`.

<img width="800" height="480" alt="image" src="https://github.com/user-attachments/assets/5f7a9913-84a1-419f-849e-fb5c76c379b3" />


## The second commit
Allows you to provide a custom preview function. Basegame's `forUpgrade` only supports upgrades, but this allows you to preview with other modifiers as well.

<img width="800" height="480" alt="image" src="https://github.com/user-attachments/assets/4583fa19-6301-4c63-b800-226366c2dafe" />

I'm not sure if adding a single overload is enough, but I did it this way because there are too many constructor overloads already.